### PR TITLE
Client settings and misc polish

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -9,7 +9,7 @@ asciidoc:
   attributes:
     page-nav-header-levels: 2
     server_version: '7.6.2'
-    sdk_current_version: '0.1.0-SNAPSHOT'
+    sdk_current_version: '1.0.0'
     sdk_dot_minor: '1.0'
     sdk_dot_major: '1.x'
     version-server: '7.6'

--- a/modules/hello-world/pages/overview.adoc
+++ b/modules/hello-world/pages/overview.adoc
@@ -139,10 +139,10 @@ public class Example {
     try (Cluster cluster = Cluster.newInstance(
       connectionString,
       Credential.of(username, password),
+      // The third parameter is optional.
+      // This example sets the default query timeout to 2 minutes.
       clusterOptions -> clusterOptions
-        // Configure a secure connection to a Couchbase internal pre-production cluster.
-        // (Omit this when connecting to a production cluster!)
-        .security(it -> it.trustOnlyCertificates(Certificates.getNonProdCertificates()))
+        .timeout(it -> it.queryTimeout(Duration.ofMinutes(2)))
     )) {
 
       // Execute a query and buffer all result rows in client memory.

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -29,7 +29,6 @@ The examples below use these imports:
 import com.couchbase.columnar.client.java.Cluster;
 import com.couchbase.columnar.client.java.Credential;
 import com.couchbase.columnar.client.java.QueryResult;
-import com.couchbase.columnar.client.java.internal.Certificates;
 ----
 
 A connection to a Capella Columnar cluster is represented by a `Cluster` object.
@@ -42,16 +41,22 @@ The simplest way to create a `Cluster` object is to call `Cluster.newInstance()`
 ----
 public class Example {
   public static void main(String[] args) {
-    var connectionString = "cb.<your-endpoint>.cloud.couchbase.com"
+    var connectionString = "couchbases://cb.<your-endpoint>.cloud.couchbase.com";
     var username = "...";
     var password = "...";
 
     try (Cluster cluster = Cluster.newInstance(
       connectionString,
-      Credential.of(username, password),
-      clusterOptions -> clusterOptions
-    ))
+      Credential.of(username, password)
+    )) {
+        // Interact with the cluster here
+    }
+  }
+}
 ----
+
+WARNING: The above example uses a `try-with-resources` block to ensure the `Cluster` instance gets closed at the end.
+It's important to either use a `try-with-resources` block, or make sure to call `cluster.close()` when you're done with the cluster.
 
 The client certificate for connecting to a Capella Columnar instance is included in the SDK installation.
 
@@ -70,9 +75,9 @@ Just as in a URI, the first parameter is prefixed by a question mark (`?`).
 For Columnar, as for all Capella products, connection must be made with Transport Layer Security (TLS) -- for full encryption of client-side traffic --
 for which the `couchbases://` schema is used as the root of the connection string (note the trailing *s*).
 
-.Simple connection string with one seed node
+.Simple connection string
 ----
-cb.<your-endpoint>.cloud.couchbase.com
+couchbases://cb.<your-endpoint>.cloud.couchbase.com
 ----
 
 ////
@@ -91,7 +96,7 @@ The client fetches the full address list from the first node it is able to conta
 
 .Connection string with two parameters
 ----
-cb.<your-endpoint>.cloud.couchbase.com?io.networkResolution=external&timeout.kvTimeout=10s
+couchbases://cb.<your-endpoint>.cloud.couchbase.com?timeout.connect_timeout=30s&timeout.query_timeout=2m
 ----
 
 The full list of recognized parameters is documented in the xref:ref:client-settings.adoc[client settings reference].

--- a/modules/ref/pages/client-settings.adoc
+++ b/modules/ref/pages/client-settings.adoc
@@ -1,13 +1,203 @@
 = Client Settings
-:description: Most settings can be changed through the connection string.
-// :description: pass:q[The `ClusterEnvironment` class enables you to configure Columnar Java SDK options for security, timeouts, reliability, and performance.]
+:description: Change the SDK's behavior by configuring client settings.
 :page-toclevels: 2
-
 
 [abstract]
 {description}
 
+Client settings can be configured by writing code, or by including parameters in the connection string.
 
-// connstr?
 
-*TODO -- most common options*
+[#configure-with-code]
+== Configure with Code
+
+To configure SDK client settings by writing code, provide a configuration callback when creating the `Cluster` instance. Here's an example that configures several settings by passing the optional third argument to `Cluster.newInstance()`:
+
+[source,java]
+----
+Cluster cluster = Cluster.newInstance(
+    connectionString,
+    Credential.of(username, password),
+    clusterOptions -> clusterOptions // <1>
+        .timeout(timeoutOptions -> timeoutOptions // <2>
+            .connectTimeout(Duration.ofSeconds(30))
+            .queryTimeout(Duration.ofMinutes(2))
+        ) // <3>
+        .security(securityOptions -> securityOptions // <4>
+            .cipherSuites(List.of("MY_APPROVED_CIPHER_SUITE"))
+        )
+);
+----
+<1> The parameter type is `Consumer<ClusterOptions>`.
+The SDK passes a `ClusterOptions` object to your consumer.
+Configure the options by calling methods on the given object.
+
+<2> The same callback pattern extends to the sub-builders for different categories. For example, `ClusterOptions.timeout()` takes a `Consumer<TimeoutOptions>`.
+
+<3> The `*Options` classes are mutable builders.
+Every method returns the same builder, allowing for method call chaining.
+
+<4> Most users won't need to configure security settings, but it's shown here for completeness.
+
+TIP: You don't need to call every method in the above example; call only the methods where you want to override the client setting's default value.
+
+
+[#configure-with-connection-string]
+== Configure with Connection String Parameters
+
+Another way to configure client settings is to include parameters in the connection string.
+Here is an example connection string with two parameters:
+
+[source]
+----
+couchbases://example.com?timeout.connect_timeout=30s&timeout.queryTimeout=2m
+----
+
+If the same parameter name appears in the connection string more than once, the SDK uses the rightmost value.
+
+If the same client setting is specified both in code and in the connection string, the SDK uses the value in the connection string.
+
+TIP: If your application reads the connection string from a config file (or other external source), you can change the connection string to override client settings without having to recompile your code.
+
+
+[#durations]
+=== Durations
+
+For client settings that represent durations, the connection string parameter's value is specified using the format accepted by https://pkg.go.dev/time#ParseDuration[Golang's time.ParseDuration] method.
+
+> A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+Note that although the Golang syntax allows negative durations, the SDK rejects non-positive timeout durations.
+
+
+[#booleans]
+=== Booleans
+
+For boolean client settings, the SDK expects the connection string value to be `true` or `false` (case-sensitive).
+
+The values `1` and `0` may be used as aliases for `true` and `false`.
+
+
+[#client-settings-rerence]
+== Client Settings Reference
+
+This section describes all client settings supported by the SDK.
+
+
+[#timeout-options]
+=== Timeout Options
+
+Configuring timeouts gives you control over how long the SDK waits for operations to succeed or fail.
+
+[cols="1,1,2"]
+|===
+|Connection string parameter |Default value |Description
+
+|[[timeout.connect_timeout]]`timeout.connect_timeout`
+|`10s` (10 seconds)
+|Time limit for establishing a network connection.
+Indirectly controls SDK bootstrap timeout, which is 1.5 times this duration.
+
+|[[timeout.query_timeout]]`timeout.query_timeout`
+|`10m` (10 minutes)
+|Default query execution time limit. Can be overridden for specific queries by setting the `timeout` query option when executing the query.
+|===
+
+
+[#security-options]
+=== Security Options
+
+The SDK is secure by default.
+Unless configured to trust a different root certificate, it trusts only the Couchbase Capella certificate authority whose root certificate is bundled with the SDK.
+
+You probably won't need to configure the SDK's security options unless:
+
+* You have special security compliance requirements that restrict the set of allowed TLS cipher suites.
+
+* You are a Couchbase employee working with an internal non-production hosted service, or a local server installation.
+
+[cols="1,1,2"]
+|===
+|Connection string parameter |Default value |Description
+
+|[[security.cipher_suites]]`security.cipher_suites`
+|Empty string / empty list (SDK uses any cipher suite supported by the JVM)
+|Limits the set of cipher suites the SDK may use when negotiating secure connections to the server.
+
+Leave this at the default value unless you have special security compliance requirements.
+
+When specifying this as a connection string parameter, the value is a comma-delimited list with no whitespace.
+
+Consult your JVM reference documentation for a list of supported cipher suite names.
+
+|[[security.trust_only_non_prod]]`security.trust_only_non_prod`
+|N/A
+|Setting this to `true` enables the SDK to connect securely to the internal Couchbase non-production hosted service, which uses a different certificate authority than the production site.
+
+You probably won't need to do this unless you are a Couchbase employee.
+
+|[[security.trust_only_pem_file]]`security.trust_only_pem_file`
+|N/A
+|Filesystem path of the PEM-encoded root certificate(s) to trust instead of the Couchbase Capella certificate authority (CA) root certificate bundled with the SDK.
+
+In the unlikely event the Couchbase Capella CA is compromised, you can use this to point the SDK at an updated CA certificate without having to immediately upgrade to a new version of the SDK (which will include the updated CA certificate and trust it by default).
+|===
+
+
+[#danger-zone]
+==== Danger Zone
+Finally, there is one security option whose use is strongly discouraged in nearly all circumstances.
+Setting `security.disable_server_certificate_verification` to `true` allows the SDK to connect to any server, regardless of whether the server presents a certificate trusted by the SDK.
+
+CAUTION: Disabling server certificate verification is roughly equivalent to sending your credentials and all data over an insecure connection.
+Don't do this unless connecting to a server running locally on your development machine.
+
+
+[#deserializer]
+=== Deserializer
+
+The SDK uses a component called a `Deserializer` to convert query result rows into Java objects. The default implementation is `JacksonDeserializer`, a thin wrapper around a https://github.com/FasterXML/jackson[Jackson] `ObjectMapper`.
+
+By default, a Jackson `ObjectMapper` throws an exception if it encounters a JSON field that does not match the structure of the target class.
+Here's an example that shows how to configure the `ObjectMapper` with different behavior:
+
+[source,java]
+----
+ObjectMapper mapper = JsonMapper.builder()
+    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES) // <1>
+    .build();
+
+Cluster cluster = Cluster.connect(
+    connectionString,
+    Credential.of(username, password),
+    clusterOptions -> clusterOptions
+        .deserializer(new JacksonDeserializer(mapper))
+);
+----
+<1> Ignore unknown properties instead of throwing exception.
+
+This cluster option specifies the _default_ deserializer.
+You can override the deserializer for a specific query by setting the `serializer` query option when executing the query.
+
+TIP: If you prefer not to work with the `Deserializer` interface, you can always call `row.bytes()` to get a row's content as a raw byte array.
+Then you can process the byte array however you like.
+
+
+[#custom-deserializers]
+==== Custom deserializers
+
+Implement the `Deserializer` interface to add support for other JSON processing libraries.
+The SDK source code repository includes https://github.com/couchbase/couchbase-jvm-clients/tree/master/columnar-java-client/src/test/java/com/couchbase/columnar/client/java/examples/codec[examples for Gson and DSL-JSON] that you can copy into your own project or use as a starting point for other libraries.
+
+
+[#dns-srv]
+=== DNS SRV
+
+By default, the SDK does a DNS SRV lookup on the connection string's hostname in order to locate nodes in the cluster.
+If for some reason you need to disable this behavior, set the `srv` connection string parameter to `false`.
+For example:
+
+[source]
+----
+couchabses://example.com?srv=false
+----


### PR DESCRIPTION
* Fleshed out "Client Settings"

* Updated version for imminent 1.0.0 GA

* Noted it's important to call Cluster.close()

* Polished imports and connection string examples

* Updated code examples to target external audience, who don't care about Certificates.getNonProdCertificates().