### PR TITLE
Minor polish

### DIFF
--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -58,10 +58,8 @@ public class Example {
 WARNING: The above example uses a `try-with-resources` block to ensure the `Cluster` instance gets closed at the end.
 It's important to either use a `try-with-resources` block, or make sure to call `cluster.close()` when you're done with the cluster.
 
-The client certificate for connecting to a Capella Columnar instance is included in the SDK installation.
-
-NOTE: Capella's root certificate is *not* signed by a well known CA (Certificate Authority).
-However, as the certificate is bundled with the SDK, it is trusted by default.
+NOTE: Capella's root certificate is *not* signed by a well known Certificate Authority.
+However, the certificate is bundled with the SDK, and is automatically trusted unless you specify a different certificate to trust.
 
 
 

--- a/modules/ref/pages/client-settings.adoc
+++ b/modules/ref/pages/client-settings.adoc
@@ -73,7 +73,7 @@ Note that although the Golang syntax allows negative durations, the SDK rejects 
 [#booleans]
 === Booleans
 
-For boolean client settings, the SDK expects the connection string value to be `true` or `false` (case-sensitive).
+For boolean client settings, the SDK expects the connection string parameter value to be `true` or `false` (case-sensitive).
 
 The values `1` and `0` may be used as aliases for `true` and `false`.
 
@@ -177,7 +177,7 @@ Cluster cluster = Cluster.connect(
 <1> Ignore unknown properties instead of throwing exception.
 
 This cluster option specifies the _default_ deserializer.
-You can override the deserializer for a specific query by setting the `serializer` query option when executing the query.
+You can override the deserializer for a specific query by setting the `deserializer` query option when executing the query.
 
 TIP: If you prefer not to work with the `Deserializer` interface, you can always call `row.bytes()` to get a row's content as a raw byte array.
 Then you can process the byte array however you like.


### PR DESCRIPTION
* Removed references to "client certificate". A client certificate is typically used for authentication via mutual TLS, but Columnar does not support using client certificates for auth. What we're really talking about is the *server's* TLS certificate

* Fix query option name: serializer -> deserializer

* Clarify that we're talking about the connection string *parameter value*