### PR TITLE
Remove download link from release notes

### DIFF
--- a/modules/project-docs/pages/columnar-sdk-release-notes.adoc
+++ b/modules/project-docs/pages/columnar-sdk-release-notes.adoc
@@ -31,7 +31,6 @@ any changes to expected behavior are noted in the release notes that follow.
 
 First GA release of the Java columnar SDK.
 
-https://packages.couchbase.com/clients/java/1.0.0/Couchbase-Columnar-Java-Client-1.0.0.zip[Download] |
 https://docs.couchbase.com/sdk-api/couchbase-columnar-java-client-1.0.0/com.couchbase.columnar.client.java/module-summary.html[API Reference]
 
 


### PR DESCRIPTION
Motivation
----------
There is no archive to download. The Columnar SDK
is distributed only via Maven Central.