### PR TITLE
Remove reference to "client" certificate

### DIFF
--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -49,10 +49,7 @@ include::{sdk_api}@columnar-sdk:shared:partial$network-requirements.adoc[tag=lan
 Capella Columnar is a fully hosted service, continually updated, and offering the latest version --
 with users having a few weeks to upgrade from the previous version.
 As such, the latest Couchbase Columnar SDKs are tested against the latest versions.
-Where older versions of the {name-sdk} pre-date significant new features in Columar, those differences will be noted in this section.
-
-
-To make development easier, the SDK includes the Capella client certificate ready installed.
+Where older versions of the {name-sdk} pre-date significant new features in Columnar, those differences will be noted in this section.
 
 
 


### PR DESCRIPTION
Motivation
----------
Columnar doesn't use client certificates
(which are for mutual TLS authentication).

This sentence was referring to the server certificate. The user doesn't need to think about those, though.

This _might_ be a good place to mention that
if the Capella certificate authority is compromised, you'll need to upgrade the SDK or configure it to use a new certificate. However, that would require careful wordsmithing, and can be added later.

Also, fixed a typo: Colmar -> Columnar